### PR TITLE
Include the correct headers in type/deprecated/constant_sequence.h

### DIFF
--- a/fatal/type/deprecated/constant_sequence.h
+++ b/fatal/type/deprecated/constant_sequence.h
@@ -14,6 +14,8 @@
 #include <fatal/type/array.h>
 #include <fatal/type/deprecated/type_list.h>
 
+#include <memory>
+#include <string>
 #include <type_traits>
 
 namespace fatal {


### PR DESCRIPTION
Because the code is dependent on `std::char_traits` and `std::allocator` being defined, but, if this header is included before `<string>` and `<memory>` are included, they won't be, causing the build to fail.
This is the case when building Thrift on OSX, and was blocking HHVM from being able to update to the newest version of Thrift.