### PR TITLE
include <cstdlib> in sequence.h

### DIFF
--- a/fatal/type/sequence.h
+++ b/fatal/type/sequence.h
@@ -20,6 +20,7 @@ template <typename T, T...> struct sequence;
 
 } // namespace fatal {
 
+#include <cstdlib>
 #include <cstdint>
 
 #include <fatal/type/impl/sequence.h>


### PR DESCRIPTION
OSX clang `cstdint` doesn't include `std::size_t`; that's located in `cstdlib`