### PR TITLE
Reimplement fatal::foreach to iterate via param-pack expansion

### DIFF
--- a/fatal/type/foreach.h
+++ b/fatal/type/foreach.h
@@ -11,6 +11,7 @@
 #define FATAL_INCLUDE_fatal_type_foreach_h
 
 #include <fatal/type/apply.h>
+#include <fatal/type/sequence.h>
 
 #include <utility>
 
@@ -19,12 +20,11 @@
 namespace fatal {
 
 // TODO: MOVE SOMEWHERE ELSE??
-template <typename T, typename Visitor, typename... Args>
-static void foreach(Visitor &&visitor, Args &&...args) {
-  apply_to<T, impl_fe::fe>::f(
-    std::forward<Visitor>(visitor),
-    std::forward<Args>(args)...
-  );
+template <typename List, typename Visitor, typename... Args>
+static void foreach(Visitor&& visitor, Args&&... args) {
+  using IndexSeq = fatal::make_index_sequence<fatal::size<List>::value>;
+  impl_fe::fe<List, IndexSeq>::f(
+      std::forward<Visitor>(visitor), std::forward<Args>(args)...);
 }
 
 } // namespace fatal {

--- a/fatal/type/impl/foreach.h
+++ b/fatal/type/impl/foreach.h
@@ -10,26 +10,27 @@
 #ifndef FATAL_INCLUDE_fatal_type_impl_foreach_h
 #define FATAL_INCLUDE_fatal_type_impl_foreach_h
 
+#include <fatal/type/list.h>
 #include <fatal/type/tag.h>
 
 namespace fatal {
 namespace impl_fe {
 
-template <typename...>
+template <typename, typename>
 struct fe {
-  template <std::size_t = 0, typename... Args>
-  static void f(Args &&...) {}
+  template <typename Visitor, typename... Args>
+  static void go(Visitor&&, Args&&...) {}
 };
 
-template <typename T, typename... Args>
-struct fe<T, Args...> {
-  template <std::size_t Index = 0, typename Visitor, typename... VArgs>
-  static void f(Visitor &&visitor, VArgs &&...args) {
-    visitor(indexed<T, Index>(), args...);
-    fe<Args...>::template f<Index + 1>(
-      std::forward<Visitor>(visitor),
-      std::forward<VArgs>(args)...
-    );
+template <typename... Els, std::size_t... Indexes>
+struct fe<list<Els...>, index_sequence<Indexes...>> {
+  static_assert(sizeof...(Els) == sizeof...(Indexes), "size mismatch");
+  static constexpr std::size_t size = sizeof...(Els);
+
+  template <typename Visitor, typename... Args>
+  static void f(Visitor&& visitor, Args&&... args) {
+    bool _[size] = {(visitor(indexed<Els, Indexes>{}, args...), false)...};
+    (void) _;
   }
 };
 

--- a/fatal/type/test/foreach_test.cpp
+++ b/fatal/type/test/foreach_test.cpp
@@ -1,0 +1,78 @@
+#include <fatal/type/foreach.h>
+
+#include <fatal/test/driver.h>
+#include <fatal/log/log.h>
+
+#include <string>
+#include <vector>
+
+namespace fatal {
+
+struct example_visitor {
+  template <typename Type, std::size_t Index>
+  void operator()(
+      indexed<Type, Index>,
+      const std::string suffix,
+      std::vector<std::string>& out) {
+    out.push_back(to_string(Type::get(), "_", Index, "_", suffix));
+  }
+};
+
+FATAL_TEST(foreach_test, empty) {
+  using types = list<>;
+
+  auto actual = std::vector<std::string>{};
+  foreach<types>(example_visitor(), "s", actual);
+
+  const auto expected = std::vector<std::string>{};
+  FATAL_EXPECT_TRUE(expected == actual);
+}
+
+FATAL_TEST(foreach_test, basic_example) {
+  struct foo { static std::string get() { return "foo"; } };
+  struct bar { static std::string get() { return "bar"; } };
+  struct baz { static std::string get() { return "baz"; } };
+  using types = list<foo, bar, baz>;
+
+  auto actual = std::vector<std::string>{};
+  foreach<types>(example_visitor(), "s", actual);
+
+  const auto expected =
+    std::vector<std::string>{"foo_0_s", "bar_1_s", "baz_2_s"};
+  FATAL_EXPECT_TRUE(expected == actual);
+}
+
+// replicate<typename T, std::size_t N>
+//
+// An alias to a list<T...> with T replicated N times in the list.
+template <typename T, typename>
+struct replicate_impl;
+template <typename T, std::size_t... Ns>
+struct replicate_impl<T, index_sequence<Ns...>> {
+  template <std::size_t N>
+  using type_from_index = T;
+  using type = list<type_from_index<Ns>...>;
+};
+template <typename T, std::size_t N>
+using replicate = typename replicate_impl<T, make_index_sequence<N>>::type;
+
+FATAL_TEST(foreach_test, very_long_type_list) {
+  struct foo { static std::string get() { return "foo"; } };
+  constexpr auto size = 1ULL << 12;
+  using types = replicate<foo, size>;
+  static_assert(fatal::size<types>::value == size, "size mismatch");
+
+  auto actual = std::vector<std::string>{};
+  foreach<types>(example_visitor(), "s", actual);
+
+  const auto expected = [] {
+    std::vector<std::string> ret{};
+    for (auto i = size_t(0); i < size; ++i) {
+      ret.push_back(to_string("foo_", i, "_s"));
+    };
+    return ret;
+  } ();
+  FATAL_EXPECT_TRUE(expected == actual);
+}
+
+}


### PR DESCRIPTION
The previous version of fatal::foreach iterates the type-list via
compile-time recursion. The proposed version iterates the type-list via
param-pack expansion.

The compilation performance appears to be the same, but, if the visitor
has a compiler error, then the compiler will emit only two lines of
template instantiation. The previous version would emit `O(N)` lines of
template instantiation, where N ins the size of the type list. For type
lists of small order and where the element type names are small, this
makes little difference. But for long type lists or for type lists where
the member types are very long, such as where the member types are
template types applied to many template type arguments which themselves
may have long names, this makes a large difference.

Moreover, the previous version would fail to compile if the recursion
over the type list exceeds the template instantiation depth limit, as
specified with -ftemplate-depth (or as specified by the compiler
default). The proposed version compiles even with such very long type
lists because it emits a template instantiation tree of depth `O(1)`
instead of a template instantiation tree of depth `O(N)`.

Ran the new unit-test like this:

```
USE_CC=g++ USE_STD=c++1y NO_CLEAR=true ./test.sh type foreach
USE_CC=clang++ USE_STD=c++1y NO_CLEAR=true ./test.sh type foreach
```