### PR TITLE
Add `add_const_from_t` and `add_reference_from_t` aliases

### DIFF
--- a/fatal/type/constify.h
+++ b/fatal/type/constify.h
@@ -43,10 +43,10 @@ namespace fatal {
  */
 template <typename T>
 struct constify {
-  using type = typename add_reference_from<
+  using type = add_reference_from_t<
     typename std::decay<T>::type const,
     T
-  >::type;
+  >;
 };
 
 } // namespace fatal

--- a/fatal/type/data_member_getter.h
+++ b/fatal/type/data_member_getter.h
@@ -197,13 +197,13 @@ struct data_member_try_getter {
     \
     template <typename Owner> \
     struct reference { \
-      using ref_impl = typename ::fatal::add_reference_from< \
+      using ref_impl = ::fatal::add_reference_from_t< \
         typename ::fatal::constify_from< \
           type<Owner>, \
           typename ::std::remove_reference<Owner>::type \
         >::type, \
         Owner && \
-      >::type; \
+      >; \
       \
       static_assert(std::is_reference<ref_impl>::value, ""); \
     }; \

--- a/fatal/type/qualifier.h
+++ b/fatal/type/qualifier.h
@@ -70,12 +70,15 @@ enum class ref_qualifier:
  *
  *  // yields `foo`
  *  using result1 = add_const_from<foo, int>::type;
+ *  using result1 = add_const_from_t<foo, int>;
  *
  *  // yields `foo const`
  *  using result2 = add_const_from<foo, int const>::type;
+ *  using result2 = add_const_from_t<foo, int const>;
  *
  *  // yields `foo const`
  *  using result3 = add_const_from<foo const, int const>::type;
+ *  using result3 = add_const_from_t<foo const, int const>;
  *
  * @author: Marcelo Juchem <marcelo@fb.com>
  */
@@ -89,6 +92,9 @@ struct add_const_from<T, TFrom const> {
   using type = typename std::add_const<T>::type;
 };
 
+template <typename T, typename TFrom>
+using add_const_from_t = typename add_const_from<T, TFrom>::type;
+
 /**
  * Given types `T` and `U`:
  * - if `U` is not a reference, yield `T`
@@ -101,21 +107,27 @@ struct add_const_from<T, TFrom const> {
  *
  *  // yields `foo`
  *  using result1 = add_reference_from<foo, int>::type;
+ *  using result1 = add_reference_from_t<foo, int>;
  *
  *  // yields `foo &&`
  *  using result2 = add_reference_from<foo &&, int>::type;
+ *  using result2 = add_reference_from_t<foo &&, int>;
  *
  *  // yields `foo &`
  *  using result3 = add_reference_from<foo, int &>::type;
+ *  using result3 = add_reference_from_t<foo, int &>;
  *
  *  // yields `foo &`
  *  using result4 = add_reference_from<foo &&, int &>::type;
+ *  using result4 = add_reference_from_t<foo &&, int &>;
  *
  *  // yields `foo &&`
  *  using result5 = add_reference_from<foo, int &&>::type;
+ *  using result5 = add_reference_from_t<foo, int &&>;
  *
  *  // yields `foo &`
  *  using result6 = add_reference_from<foo &, int &&>::type;
+ *  using result6 = add_reference_from_t<foo &, int &&>;
  *
  * @author: Marcelo Juchem <marcelo@fb.com>
  */
@@ -133,6 +145,9 @@ template <typename T, typename TFrom>
 struct add_reference_from<T, TFrom &&> {
   using type = typename std::add_rvalue_reference<T>::type;
 };
+
+template <typename T, typename TFrom>
+using add_reference_from_t = typename add_reference_from<T, TFrom>::type;
 
 } // namespace fatal {
 

--- a/fatal/type/test/data_member_getter_test.cpp
+++ b/fatal/type/test/data_member_getter_test.cpp
@@ -1896,7 +1896,7 @@ FATAL_TEST(chained_data_member_getter, getter) {
     ); \
     \
     FATAL_EXPECT_SAME< \
-      add_reference_from< \
+      add_reference_from_t< \
         constify_from< \
           decltype(std::move(Data.Outer).Inner), \
           constify_from< \
@@ -1905,12 +1905,12 @@ FATAL_TEST(chained_data_member_getter, getter) {
           >::type \
         >::type &&, \
         decltype(std::move(Data).Outer) \
-      >::type, \
+      >, \
       decltype(getter::ref(std::move(Data))) \
     >(); \
     \
     FATAL_EXPECT_SAME< \
-      add_reference_from< \
+      add_reference_from_t< \
         constify_from< \
           decltype(std::move(Data).Outer.Inner), \
           constify_from< \
@@ -1919,7 +1919,7 @@ FATAL_TEST(chained_data_member_getter, getter) {
           >::type \
         >::type &&, \
         decltype(std::move(Data).Outer) \
-      >::type, \
+      >, \
       decltype(data_member_referencer<getter>()(std::move(Data))) \
     >(); \
   } while (false)

--- a/fatal/type/test/qualifier_test.cpp
+++ b/fatal/type/test/qualifier_test.cpp
@@ -45,7 +45,7 @@ FATAL_TEST(qualifier, cv_qualifier_bitwise_and) {
 
 FATAL_TEST(qualifier, add_const_from) {
 # define TEST_IMPL(From, T, ...) \
-  FATAL_EXPECT_SAME<__VA_ARGS__, add_const_from<T, From>::type>();
+  FATAL_EXPECT_SAME<__VA_ARGS__, add_const_from_t<T, From>>();
 
   TEST_IMPL(int, int &&, int &&);
   TEST_IMPL(int, int &, int &);
@@ -90,7 +90,7 @@ FATAL_TEST(qualifier, add_const_from) {
 
 FATAL_TEST(qualifier, add_reference_from) {
 # define TEST_IMPL(From, T, ...) \
-  FATAL_EXPECT_SAME<__VA_ARGS__, add_reference_from<T, From>::type>();
+  FATAL_EXPECT_SAME<__VA_ARGS__, add_reference_from_t<T, From>>();
 
   TEST_IMPL(int &&, int &&, int &&);
   TEST_IMPL(int &&, int &, int &);


### PR DESCRIPTION
These will make `add_const_from` and `add_reference_from` easier to use
with dependent arguments.

Test them by switching the tests to use them.