### PR TITLE
Add `add_volatile_from` and `add_cv_from`.

### DIFF
--- a/fatal/type/qualifier.h
+++ b/fatal/type/qualifier.h
@@ -96,6 +96,102 @@ template <typename T, typename TFrom>
 using add_const_from_t = typename add_const_from<T, TFrom>::type;
 
 /**
+ * Applies `std::add_volatile` to a type iff some other type is volatile.
+ *
+ * Example:
+ *
+ *  struct foo {};
+ *
+ *  // yields `foo`
+ *  using result1 = add_volatile_from<foo, int>::type;
+ *  using result1 = add_volatile_from_t<foo, int>;
+ *
+ *  // yields `foo const`
+ *  using result2 = add_volatile_from<foo, int volatile>::type;
+ *  using result2 = add_volatile_from_t<foo, int volatile>;
+ *
+ *  // yields `foo const`
+ *  using result3 = add_volatile_from<foo volatile, int volatile>::type;
+ *  using result3 = add_volatile_from_t<foo volatile, int volatile>;
+ *
+ * @author: Marcelo Juchem <marcelo@fb.com>
+ */
+template <typename T, typename>
+struct add_volatile_from {
+  using type = T;
+};
+
+template <typename T, typename TFrom>
+struct add_volatile_from<T, TFrom volatile> {
+  using type = typename std::add_volatile<T>::type;
+};
+
+template <typename T, typename TFrom>
+using add_volatile_from_t = typename add_volatile_from<T, TFrom>::type;
+
+/**
+ * Applies `std::add_const` to a type iff some other type is const.
+ * Applies `std::add_volatile` to a type iff some other type is volatile.
+ * Applies `std::add_cv` toa  type iff some other type is const volatile.
+ *
+ * Example:
+ *
+ *  struct foo {};
+ *
+ *  // yields `foo`
+ *  using result1 = add_cv_from<foo, int>::type;
+ *  using result1 = add_cv_from_t<foo, int>;
+ *
+ *  // yields `foo const`
+ *  using result2 = add_cv_from<foo, int const>::type;
+ *  using result2 = add_cv_from_t<foo, int const>;
+ *
+ *  // yields `foo const`
+ *  using result3 = add_cv_from<foo const, int const>::type;
+ *  using result3 = add_cv_from_t<foo const, int const>;
+ *
+ *  // yields `foo volatile`
+ *  using result4 = add_cv_from<foo, int volatile>::type;
+ *  using result4 = add_cv_from_t<foo, int volatile>;
+ *
+ *  // yields `foo volatile`
+ *  using result5 = add_cv_from<foo volatile, int volatile>::type;
+ *  using result5 = add_cv_from_t<foo volatile, int volatile>;
+ *
+ *  // yields `foo const volatile`
+ *  using result6 = add_cv_from<foo, int const volatile>::type;
+ *  using result6 = add_cv_from_t<foo, int const volatile>;
+ *
+ *  // yields `foo const volatile`
+ *  using result7 = add_cv_from<foo const volatile, int const volatile>::type;
+ *  using result7 = add_cv_from_t<foo const volatile, int const volatile>;
+ *
+ * @author: Marcelo Juchem <marcelo@fb.com>
+ */
+template <typename T, typename>
+struct add_cv_from {
+  using type = T;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_from<T, TFrom const> {
+  using type = typename std::add_const<T>::type;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_from<T, TFrom volatile> {
+  using type = typename std::add_volatile<T>::type;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_from<T, TFrom const volatile> {
+  using type = typename std::add_cv<T>::type;
+};
+
+template <typename T, typename TFrom>
+using add_cv_from_t = typename add_cv_from<T, TFrom>::type;
+
+/**
  * Given types `T` and `U`:
  * - if `U` is not a reference, yield `T`
  * - if `U` is an l-value reference, yield `std::add_lvalue_reference<T>::type`

--- a/fatal/type/test/qualifier_test.cpp
+++ b/fatal/type/test/qualifier_test.cpp
@@ -88,6 +88,75 @@ FATAL_TEST(qualifier, add_const_from) {
 # undef TEST_IMPL
 }
 
+FATAL_TEST(qualifier, add_volatile_from) {
+# define TEST_IMPL(From, T, ...) \
+  FATAL_EXPECT_SAME<__VA_ARGS__, add_volatile_from_t<T, From>>();
+
+  TEST_IMPL(int, int &&, int &&);
+  TEST_IMPL(int, int &, int &);
+  TEST_IMPL(int, int *&&, int *&&);
+  TEST_IMPL(int, int *&, int *&);
+  TEST_IMPL(int, int *, int *);
+  TEST_IMPL(int, int, int);
+  TEST_IMPL(int, int *volatile&&, int *volatile&&);
+  TEST_IMPL(int, int *volatile &, int *volatile &);
+  TEST_IMPL(int, int *volatile, int *volatile);
+  TEST_IMPL(int, int volatile &&, int volatile &&);
+  TEST_IMPL(int, int volatile &, int volatile &);
+  TEST_IMPL(int, int volatile *&&, int volatile *&&);
+  TEST_IMPL(int, int volatile *&, int volatile *&);
+  TEST_IMPL(int, int volatile *, int volatile *);
+  TEST_IMPL(int, int volatile *volatile &&, int volatile *volatile &&);
+  TEST_IMPL(int, int volatile *volatile &, int volatile *volatile &);
+  TEST_IMPL(int, int volatile *volatile, int volatile *volatile);
+  TEST_IMPL(int, int volatile, int volatile);
+
+  TEST_IMPL(int volatile, int &&, int &&);
+  TEST_IMPL(int volatile, int &, int &);
+  TEST_IMPL(int volatile, int, int volatile);
+  TEST_IMPL(int volatile, int *&&, int *&&);
+  TEST_IMPL(int volatile, int *&, int *&);
+  TEST_IMPL(int volatile, int *, int *volatile);
+  TEST_IMPL(int volatile, int *volatile &&, int *volatile &&);
+  TEST_IMPL(int volatile, int *volatile &, int *volatile &);
+  TEST_IMPL(int volatile, int *volatile, int *volatile);
+  TEST_IMPL(int volatile, int volatile &&, int volatile &&);
+  TEST_IMPL(int volatile, int volatile &, int volatile &);
+  TEST_IMPL(int volatile, int volatile, int volatile);
+  TEST_IMPL(int volatile, int volatile *&&, int volatile *&&);
+  TEST_IMPL(int volatile, int volatile *&, int volatile *&);
+  TEST_IMPL(int volatile, int volatile *, int volatile *volatile);
+  TEST_IMPL(int volatile, int volatile *volatile &&, int volatile *volatile &&);
+  TEST_IMPL(int volatile, int volatile *volatile &, int volatile *volatile &);
+  TEST_IMPL(int volatile, int volatile *volatile, int volatile *volatile);
+
+# undef TEST_IMPL
+}
+
+FATAL_TEST(qualifier, add_cv_from) {
+# define TEST_IMPL(From, T, ...) \
+  FATAL_EXPECT_SAME<__VA_ARGS__, add_cv_from_t<T, From>>();
+
+  TEST_IMPL(int, int, int);
+  TEST_IMPL(int, int const, int const);
+  TEST_IMPL(int, int volatile, int volatile);
+  TEST_IMPL(int, int const volatile, int const volatile);
+  TEST_IMPL(int const, int, int const);
+  TEST_IMPL(int const, int const, int const);
+  TEST_IMPL(int const, int volatile, int const volatile);
+  TEST_IMPL(int const, int const volatile, int const volatile);
+  TEST_IMPL(int volatile, int, int volatile);
+  TEST_IMPL(int volatile, int const, int const volatile);
+  TEST_IMPL(int volatile, int volatile, int volatile);
+  TEST_IMPL(int volatile, int const volatile, int const volatile);
+  TEST_IMPL(int const volatile, int, int const volatile);
+  TEST_IMPL(int const volatile, int const, int const volatile);
+  TEST_IMPL(int const volatile, int volatile, int const volatile);
+  TEST_IMPL(int const volatile, int const volatile, int const volatile);
+
+# undef TEST_IMPL
+}
+
 FATAL_TEST(qualifier, add_reference_from) {
 # define TEST_IMPL(From, T, ...) \
   FATAL_EXPECT_SAME<__VA_ARGS__, add_reference_from_t<T, From>>();


### PR DESCRIPTION
Also add the corresponding `add_volatile_from_t` and `add_cv_from_t`.

These should not be required too much per se. But we add them here to complement `add_const_from`, just as the standard has `add_volatile` and `add_cv` alongside `add_const`.