### PR TITLE
Add `add_cv_reference_from`

### DIFF
--- a/fatal/type/qualifier.h
+++ b/fatal/type/qualifier.h
@@ -245,6 +245,87 @@ struct add_reference_from<T, TFrom &&> {
 template <typename T, typename TFrom>
 using add_reference_from_t = typename add_reference_from<T, TFrom>::type;
 
+/**
+ * Combine the effects of `add_cv_from` and `add_reference_from`.
+ *
+ * Example:
+ *
+ *  struct foo {};
+ *
+ *  // yields `foo`
+ *  using result_1 = add_cv_reference_from<foo, int>::type;
+ *  using result_1 = add_cv_reference_from_t<foo, int>;
+ *
+ *  // yields `foo const &`
+ *  using result_2 = add_cv_reference_from<foo, int const &>::type;
+ *  using result_2 = add_cv_reference_from_t<foo, int const &>;
+ *
+ *  // yields `foo volatile &&`
+ *  using result_3 = add_cv_reference_from<foo, int volatile &&>::type;
+ *  using result_3 = add_cv_reference_from_t<foo, int volatile &&>;
+ *
+ * @author: Marcelo Juchem <marcelo@fb.com>
+ */
+template <typename T, typename>
+struct add_cv_reference_from {
+  using type = T;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_reference_from<T, TFrom const> {
+  using type = typename std::add_const<T>::type;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_reference_from<T &, TFrom const> {
+  using type = typename std::add_lvalue_reference<
+    typename std::add_const<T>::type
+  >::type;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_reference_from<T &&, TFrom const> {
+  using type = typename std::add_rvalue_reference<
+    typename std::add_const<T>::type
+  >::type;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_reference_from<T, TFrom volatile> {
+  using type = typename std::add_volatile<T>::type;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_reference_from<T &, TFrom volatile> {
+  using type = typename std::add_lvalue_reference<
+    typename std::add_volatile<T>::type
+  >::type;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_reference_from<T &&, TFrom volatile> {
+  using type = typename std::add_rvalue_reference<
+    typename std::add_volatile<T>::type
+  >::type;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_reference_from<T, TFrom &> {
+  using type = typename std::add_lvalue_reference<
+    typename add_cv_reference_from<T, TFrom>::type
+  >::type;
+};
+
+template <typename T, typename TFrom>
+struct add_cv_reference_from<T, TFrom &&> {
+  using type = typename std::add_rvalue_reference<
+    typename add_cv_reference_from<T, TFrom>::type
+  >::type;
+};
+
+template <typename T, typename TFrom>
+using add_cv_reference_from_t = typename add_cv_reference_from<T, TFrom>::type;
+
 } // namespace fatal {
 
 #endif // FATAL_INCLUDE_fatal_type_qualifier_h

--- a/fatal/type/test/qualifier_test.cpp
+++ b/fatal/type/test/qualifier_test.cpp
@@ -221,4 +221,21 @@ FATAL_TEST(qualifier, add_reference_from) {
 # undef TEST_IMPL
 }
 
+FATAL_TEST(qualifier, add_cv_reference_from) {
+# define TEST_IMPL(From, T, ...) \
+  FATAL_EXPECT_SAME<__VA_ARGS__, add_cv_reference_from_t<T, From>>();
+
+  TEST_IMPL(int, int, int);
+  TEST_IMPL(int, int const &, int const &);
+  TEST_IMPL(int, int volatile &&, int volatile &&);
+  TEST_IMPL(int const &, int, int const &);
+  TEST_IMPL(int const &, int const &, int const &);
+  TEST_IMPL(int const &, int volatile &&, int const volatile &);
+  TEST_IMPL(int volatile &&, int, int volatile &&);
+  TEST_IMPL(int volatile &&, int const &, int const volatile &);
+  TEST_IMPL(int volatile &&, int volatile &&, int volatile &&);
+
+# undef TEST_IMPL
+}
+
 } // namespace fatal {


### PR DESCRIPTION
Combining the effects of `add_cv_from` and `add_reference_from`.

Because of the combinatorial explosion of cases, we select only a decent
small but hopefully representative sample.