### PR TITLE
Add missing namespace anchor in data-member getters

### DIFF
--- a/fatal/type/data_member_getter.h
+++ b/fatal/type/data_member_getter.h
@@ -205,7 +205,7 @@ struct data_member_try_getter {
         Owner && \
       >; \
       \
-      static_assert(std::is_reference<ref_impl>::value, ""); \
+      static_assert(::std::is_reference<ref_impl>::value, ""); \
     }; \
     \
     FATAL_S(name, FATAL_TO_STR(__VA_ARGS__)); \

--- a/fatal/type/test/data_member_getter_test.cpp
+++ b/fatal/type/test/data_member_getter_test.cpp
@@ -97,6 +97,16 @@ struct getter_name {
 # undef TEST_IMPL
 };
 
+struct ns_tricky {
+  double std;
+  ::std::string desc;
+};
+
+struct ns_tricky_getter {
+  FATAL_DATA_MEMBER_GETTER(std, std);
+  FATAL_DATA_MEMBER_GETTER(desc, desc);
+};
+
 } // namespace data_member_getter_test {
 
 FATAL_TEST(data_member_getter, name) {
@@ -680,6 +690,16 @@ FATAL_TEST(data_member_getter, getter) {
 
 # undef TEST_IMPL
 # undef TEST_PREAMBLE_IMPL
+}
+
+FATAL_TEST(data_member_getter, namespace_std_collision) {
+  using type = data_member_getter_test::ns_tricky;
+  using getter = data_member_getter_test::ns_tricky_getter;
+  type obj;
+  getter::std::ref(obj) = 12.3;
+  getter::desc::ref(obj) = "hi";
+  FATAL_EXPECT_EQ(12.3, getter::std::ref(static_cast<type const&>(obj)));
+  FATAL_EXPECT_EQ("hi", getter::desc::ref(static_cast<type const&>(obj)));
 }
 
 ////////////////////////////////


### PR DESCRIPTION
The following example code can trigger a compilation failure:

```lang=c++
struct xyz {
  // not too uncommon to use the name `std` in statistics-related code
  FATAL_DATA_MEMBER_GETTER(std, std);
  FATAL_DATA_MEMBER_GETTER(abc, abc);
}
```

The problem is that there is a single occurrence in the macro
implementing `FATAL_DATA_MEMBER_GETTER` using `std` without `::` to its
left. In the example, in the first invocation, the local name `std` gets
defined. In the second invocation, the solitary unqualified use of the
name `std` becomes ambiguous with the namespace `std`. The intention is
to use various traits types in the `std` namespace.
