### PR TITLE
Force inlining of fatal::foreach and helpers

### DIFF
--- a/fatal/portability.h
+++ b/fatal/portability.h
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2016, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef FATAL_INCLUDE_fatal_portability_h
+#define FATAL_INCLUDE_fatal_portability_h
+
+//////////////////////////////
+// FATAL_ATTR_ALWAYS_INLINE //
+//////////////////////////////
+
+/**
+ * TODO: DOCUMENT
+ */
+
+#if _MSC_VER
+# define FATAL_ATTR_ALWAYS_INLINE __forceinline
+#elif __clang__ || __GNUC__
+# define FATAL_ATTR_ALWAYS_INLINE inline __attribute__((always_inline))
+#else
+# define FATAL_ATTR_ALWAYS_INLINE inline
+#endif
+
+//////////////////////////////////
+// FATAL_ATTR_VISIBILITY_HIDDEN //
+//////////////////////////////////
+
+/**
+ * TODO: DOCUMENT
+ */
+
+#if _MSC_VER
+# define FATAL_ATTR_VISIBILITY_HIDDEN
+#elif __clang || __GNUC__
+# define FATAL_ATTR_VISIBILITY_HIDDEN __attribute__((visibility("hidden")))
+#else
+# define FATAL_ATTR_VISIBILITY_HIDDEN
+#endif
+
+#endif

--- a/fatal/type/foreach.h
+++ b/fatal/type/foreach.h
@@ -10,6 +10,7 @@
 #ifndef FATAL_INCLUDE_fatal_type_foreach_h
 #define FATAL_INCLUDE_fatal_type_foreach_h
 
+#include <fatal/portability.h>
 #include <fatal/type/sequence.h>
 #include <fatal/type/size.h>
 
@@ -20,7 +21,8 @@
 namespace fatal {
 
 template <typename List, typename Visitor, typename... Args>
-static inline void foreach(Visitor&& visitor, Args&&... args) {
+FATAL_ATTR_ALWAYS_INLINE
+static void foreach(Visitor&& visitor, Args&&... args) {
   impl_fe::f<List, make_index_sequence<size<List>::value>>::g(
     std::forward<Visitor>(visitor),
     std::forward<Args>(args)...

--- a/fatal/type/impl/foreach.h
+++ b/fatal/type/impl/foreach.h
@@ -10,6 +10,7 @@
 #ifndef FATAL_INCLUDE_fatal_type_impl_foreach_h
 #define FATAL_INCLUDE_fatal_type_impl_foreach_h
 
+#include <fatal/portability.h>
 #include <fatal/type/list.h>
 #include <fatal/type/tag.h>
 
@@ -19,7 +20,8 @@ namespace impl_fe {
 template <typename, typename>
 struct f {
   template <typename... Args>
-  static inline void g(Args &&...) {}
+  FATAL_ATTR_ALWAYS_INLINE FATAL_ATTR_VISIBILITY_HIDDEN
+  static void g(Args &&...) {}
 };
 
 template <typename... T, std::size_t... Indexes>
@@ -27,7 +29,8 @@ struct f<list<T...>, index_sequence<Indexes...>> {
   static_assert(sizeof...(T) == sizeof...(Indexes), "size mismatch");
 
   template <typename Visitor, typename... Args>
-  static inline void g(Visitor &&visitor, Args &&...args) {
+  FATAL_ATTR_ALWAYS_INLINE FATAL_ATTR_VISIBILITY_HIDDEN
+  static void g(Visitor &&visitor, Args &&...args) {
     bool _[sizeof...(T)] = {
       (visitor(indexed<T, Indexes>{}, args...), false)...
     };


### PR DESCRIPTION
Doing this can avoid including long symbols needlessly into compiled
binaries.