### PR TITLE
avoid confusion due to typo

### DIFF
--- a/fatal/portability.h
+++ b/fatal/portability.h
@@ -36,7 +36,7 @@
 
 #if _MSC_VER
 # define FATAL_ATTR_VISIBILITY_HIDDEN
-#elif __clang || __GNUC__
+#elif __clang__ || __GNUC__
 # define FATAL_ATTR_VISIBILITY_HIDDEN __attribute__((visibility("hidden")))
 #else
 # define FATAL_ATTR_VISIBILITY_HIDDEN


### PR DESCRIPTION
clang defines __GNUC__ so this is just cleanup,
but to avoid confusion in future we should fix the __clang typo to read __clang__