### PR TITLE
Halve the trie compile-time bench input

### DIFF
--- a/fatal/type/benchmark/trie/compile-time.cpp
+++ b/fatal/type/benchmark/trie/compile-time.cpp
@@ -9,7 +9,7 @@ int main() {
 
   for (std::string needle; std::cin >> needle; ) {
     std::cout << needle << ": " << std::boolalpha
-      << trie_find<random_500_words<list, sequence>>(
+      << trie_find<random_250_words<list, sequence>>(
         needle.begin(),
         needle.end()
       )


### PR DESCRIPTION
At 500, we may blow some lowered template-instantiation-depth limits.

At 250, we are safer.