### PR TITLE
Drop support for gcc 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,6 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-4.8']
-      env:
-        COMPILER=g++-4.8
-        CPP_STD=c++0x
-
-    - os: linux
-      compiler: gcc
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-4.9']
       env:
         COMPILER=g++-4.9

--- a/fatal/type/reflect_member_function.h
+++ b/fatal/type/reflect_member_function.h
@@ -216,21 +216,10 @@ namespace detail {
     >; \
   }
 
-#ifndef __clang__
-# ifdef __GNUC__
-#   if __GNUC__ == 4 && __GNUC_MINOR__ == 8 && __GNUC_PATCHLEVEL__ < 5
-#     define FATAL_SKIP_REFLECT_MEMBER_FN_REF_QUALIFIERS
-#   endif // gcc < 4.8.5
-# endif // __GNUC__
-#endif // __clang__
-
 REFLECTED_MEMBER_FUNCTION_IMPL(none, none, );
 REFLECTED_MEMBER_FUNCTION_IMPL(c, none, const);
 REFLECTED_MEMBER_FUNCTION_IMPL(v, none, volatile);
 REFLECTED_MEMBER_FUNCTION_IMPL(cv, none, const volatile);
-
-#ifndef FATAL_SKIP_REFLECT_MEMBER_FN_REF_QUALIFIERS
-
 REFLECTED_MEMBER_FUNCTION_IMPL(none, lvalue, &);
 REFLECTED_MEMBER_FUNCTION_IMPL(c, lvalue, const &);
 REFLECTED_MEMBER_FUNCTION_IMPL(v, lvalue, volatile &);
@@ -239,8 +228,6 @@ REFLECTED_MEMBER_FUNCTION_IMPL(none, rvalue, &&);
 REFLECTED_MEMBER_FUNCTION_IMPL(c, rvalue, const &&);
 REFLECTED_MEMBER_FUNCTION_IMPL(v, rvalue, volatile &&);
 REFLECTED_MEMBER_FUNCTION_IMPL(cv, rvalue, const volatile &&);
-
-#endif // FATAL_SKIP_REFLECT_MEMBER_FN_REF_QUALIFIERS
 
 #undef REFLECTED_MEMBER_FUNCTION_IMPL
 

--- a/fatal/type/test/reflect_member_function_test.cpp
+++ b/fatal/type/test/reflect_member_function_test.cpp
@@ -53,19 +53,6 @@ struct gaz {
   int fn(bool, T const &, double *) const;
 };
 
-#ifdef FATAL_SKIP_REFLECT_MEMBER_FN_REF_QUALIFIERS
-# define CHECK_REFLECT(Class, Fn, Result, CV, CVQ, Ref, RefQ, ...) \
-    do { \
-      using reflected = reflect_member_function<decltype(&Class::Fn)>; \
-      using expected = Result(Class::*)(__VA_ARGS__) CVQ; \
-      FATAL_EXPECT_SAME<Class, reflected::owner>(); \
-      FATAL_EXPECT_SAME<Result, reflected::result>(); \
-      FATAL_EXPECT_SAME<expected, reflected::pointer>(); \
-      FATAL_EXPECT_EQ(ref_qualifier::none, reflected::ref::value); \
-      FATAL_EXPECT_EQ(cv_qualifier::CV, reflected::cv::value); \
-      FATAL_EXPECT_SAME<type_list<__VA_ARGS__>, reflected::args>(); \
-    } while (false)
-#else // FATAL_SKIP_REFLECT_MEMBER_FN_REF_QUALIFIERS
 # define CHECK_REFLECT(Class, Fn, Result, CV, CVQ, Ref, RefQ, ...) \
     do { \
       using reflected = reflect_member_function<decltype(&Class::Fn)>; \
@@ -77,7 +64,6 @@ struct gaz {
       FATAL_EXPECT_EQ(cv_qualifier::CV, reflected::cv::value); \
       FATAL_EXPECT_SAME<type_list<__VA_ARGS__>, reflected::args>(); \
     } while (false)
-#endif // FATAL_SKIP_REFLECT_MEMBER_FN_REF_QUALIFIERS
 
 FATAL_TEST(reflect_member_function, reflect_member_function) {
   CHECK_REFLECT(foo, noncv, void, none, , none, );
@@ -96,7 +82,6 @@ FATAL_TEST(reflect_member_function, reflect_member_function) {
     bar, fn_vc, R<5>, cv, const volatile, none, , A<50>, A<51> const *const &
   );
 
-#ifndef FATAL_SKIP_REFLECT_MEMBER_FN_REF_QUALIFIERS
   CHECK_REFLECT(bar, fn_lr, R<1>, none, , lvalue, &, A<10>, A<11> &&);
   CHECK_REFLECT(
     bar, fn_c_lr, R<2>, c, const, lvalue, &, A<20> const &, A<21> &
@@ -122,7 +107,6 @@ FATAL_TEST(reflect_member_function, reflect_member_function) {
     bar, fn_vc_rr, R<5>,
     cv, const volatile, rvalue, &&, A<50>, A<51> const *const &
   );
-#endif // FATAL_SKIP_REFLECT_MEMBER_FN_REF_QUALIFIERS
 
   CHECK_REFLECT(bar, fn_foo, foo &, none, , none, );
   CHECK_REFLECT(bar, operator ==, bool, c, const, none, , bar const &);


### PR DESCRIPTION
Facebook no longer supports gcc 4.8 in any core libraries, including
folly, so it is time to drop support for it here as well.