### PR TITLE
- adding `string_view::{seek*,skip*}()`

### DIFF
--- a/fatal/math/hash.h
+++ b/fatal/math/hash.h
@@ -12,6 +12,7 @@
 
 #include <fatal/math/numerics.h>
 
+#include <iterator>
 #include <limits>
 #include <type_traits>
 

--- a/fatal/string/test/string_view_test.cpp
+++ b/fatal/string/test/string_view_test.cpp
@@ -13,104 +13,101 @@
 
 namespace fatal {
 
-FATAL_TEST(string_view, sanity_check) {
-  // TODO: IMPLEMENT TESTS
+#define TEST_IMPL(Haystack, Result, Remaining, Operation, ...) \
+  do { \
+    string_view haystack(Haystack); \
+    auto const result = haystack.Operation(__VA_ARGS__); \
+    FATAL_EXPECT_EQ(Result, result); \
+    FATAL_EXPECT_EQ(Remaining, haystack); \
+  } while (false)
+
+FATAL_TEST(string_view, seek_past) {
+  TEST_IMPL("", "", "", seek_past, ' ');
+  TEST_IMPL("", "", "", seek_past, '\0');
+  TEST_IMPL("", "", "", seek_past, '\n');
+
+  TEST_IMPL("hello, world", "hello,", "world", seek_past, ' ');
+  TEST_IMPL("hello, world", "hello, world", "", seek_past, '\0');
+  TEST_IMPL("hello, world", "hello, world", "", seek_past, '\n');
+  TEST_IMPL("hello, world", "he", "lo, world", seek_past, 'l');
+  TEST_IMPL("hello, world", "", "ello, world", seek_past, 'h');
+  TEST_IMPL("hello, world", "hello, worl", "", seek_past, 'd');
 }
 
-FATAL_TEST(constructor, begin end) {
+FATAL_TEST(string_view, seek_for) {
+  TEST_IMPL("", "", "", seek_for, ' ');
+  TEST_IMPL("", "", "", seek_for, '\0');
+  TEST_IMPL("", "", "", seek_for, '\n');
+
+  TEST_IMPL("hello, world", "hello,", " world", seek_for, ' ');
+  TEST_IMPL("hello, world", "hello, world", "", seek_for, '\0');
+  TEST_IMPL("hello, world", "hello, world", "", seek_for, '\n');
+  TEST_IMPL("hello, world", "he", "llo, world", seek_for, 'l');
+  TEST_IMPL("hello, world", "", "hello, world", seek_for, 'h');
+  TEST_IMPL("hello, world", "hello, worl", "d", seek_for, 'd');
 }
 
-FATAL_TEST(constructor, s size) {
+FATAL_TEST(string_view, seek) {
+  TEST_IMPL("", "", "", seek, 0);
+
+  TEST_IMPL("hello, world", "", "hello, world", seek, 0);
+  TEST_IMPL("hello, world", "h", "ello, world", seek, 1);
+  TEST_IMPL("hello, world", "hello", ", world", seek, 5);
+  TEST_IMPL("hello, world", "hello,", " world", seek, 6);
+  TEST_IMPL("hello, world", "hello, ", "world", seek, 7);
+  TEST_IMPL("hello, world", "hello, worl", "d", seek, 11);
+  TEST_IMPL("hello, world", "hello, world", "", seek, 12);
 }
 
-FATAL_TEST(constructor, char *) {
+#undef TEST_IMPL
+
+#define TEST_IMPL(Haystack, Remaining, Operation, ...) \
+  do { \
+    string_view haystack(Haystack); \
+    auto const &result = haystack.Operation(__VA_ARGS__); \
+    FATAL_EXPECT_EQ(std::addressof(haystack), std::addressof(result)); \
+    FATAL_EXPECT_EQ(Remaining, result); \
+    FATAL_EXPECT_EQ(Remaining, haystack); \
+  } while (false)
+
+FATAL_TEST(string_view, skip_past) {
+  TEST_IMPL("", "", skip_past, ' ');
+  TEST_IMPL("", "", skip_past, '\0');
+  TEST_IMPL("", "", skip_past, '\n');
+
+  TEST_IMPL("hello, world", "world", skip_past, ' ');
+  TEST_IMPL("hello, world", "", skip_past, '\0');
+  TEST_IMPL("hello, world", "", skip_past, '\n');
+  TEST_IMPL("hello, world", "lo, world", skip_past, 'l');
+  TEST_IMPL("hello, world", "ello, world", skip_past, 'h');
+  TEST_IMPL("hello, world", "", skip_past, 'd');
 }
 
-FATAL_TEST(constructor, char const *) {
+FATAL_TEST(string_view, skip_to) {
+  TEST_IMPL("", "", skip_to, ' ');
+  TEST_IMPL("", "", skip_to, '\0');
+  TEST_IMPL("", "", skip_to, '\n');
+
+  TEST_IMPL("hello, world", " world", skip_to, ' ');
+  TEST_IMPL("hello, world", "", skip_to, '\0');
+  TEST_IMPL("hello, world", "", skip_to, '\n');
+  TEST_IMPL("hello, world", "llo, world", skip_to, 'l');
+  TEST_IMPL("hello, world", "hello, world", skip_to, 'h');
+  TEST_IMPL("hello, world", "d", skip_to, 'd');
 }
 
-FATAL_TEST(constructor, char const []) {
+FATAL_TEST(string_view, skip) {
+  TEST_IMPL("", "", skip, 0);
+
+  TEST_IMPL("hello, world", "hello, world", skip, 0);
+  TEST_IMPL("hello, world", "ello, world", skip, 1);
+  TEST_IMPL("hello, world", ", world", skip, 5);
+  TEST_IMPL("hello, world", " world", skip, 6);
+  TEST_IMPL("hello, world", "world", skip, 7);
+  TEST_IMPL("hello, world", "d", skip, 11);
+  TEST_IMPL("hello, world", "", skip, 12);
 }
 
-FATAL_TEST(constructor, char c) {
-}
-
-FATAL_TEST(constructor, universal) {
-}
-
-FATAL_TEST(constructor, copy) {
-}
-
-FATAL_TEST(constructor, move) {
-}
-
-FATAL_TEST(slice, slice) {
-}
-
-FATAL_TEST(advance_to, advance_to) {
-}
-
-FATAL_TEST(limit, limit) {
-}
-
-FATAL_TEST(data, data) {
-}
-
-FATAL_TEST(clear, clear) {
-}
-
-FATAL_TEST(size, size) {
-}
-
-FATAL_TEST(empty, empty) {
-}
-
-FATAL_TEST(cbegin, ) {
-}
-
-FATAL_TEST(cend, ) {
-}
-
-FATAL_TEST(begin, ) {
-}
-
-FATAL_TEST(end, ) {
-}
-
-FATAL_TEST(to, std::string) {
-}
-
-FATAL_TEST(operator +=, ) {
-}
-
-FATAL_TEST(operator -=, ) {
-}
-
-FATAL_TEST(operator +, ) {
-}
-
-FATAL_TEST(operator -, ) {
-}
-
-FATAL_TEST(operator ++ (prefix), ) {
-}
-
-FATAL_TEST(operator -- (prefix), ) {
-}
-
-FATAL_TEST(operator ++ (postfix), ) {
-}
-
-FATAL_TEST(operator -- (postfix), ) {
-}
-
-FATAL_TEST(operator *, ) {
-}
-
-FATAL_TEST(operator bool, ) {
-}
-
-FATAL_TEST(operator !, ) {
-}
+#undef TEST_IMPL
 
 } // namespace fatal {

--- a/fatal/string/tokenizer.h
+++ b/fatal/string/tokenizer.h
@@ -43,12 +43,12 @@ struct tokenizer {
     explicit const_iterator(string_view data):
       data_(data)
     {
-      token_.construct(data_.split_step(delimiter::value));
+      token_.construct(data_.seek_past(delimiter::value));
     }
 
     const_iterator &operator ++() {
       token_.destroy();
-      token_.construct(data_.split_step(delimiter::value));
+      token_.construct(data_.seek_past(delimiter::value));
       return *this;
     }
 


### PR DESCRIPTION
- renaming `split_step()` to a more descriptive and uniform `seek_pask()`
- adding some docs and tests