### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Our Development Process
 This library is developed internally at Facebook. It is released to the public
 in periodic (usually bi-weekly) pushes.


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

why make this change?:
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [Fatal community profile
checklist](https://github.com/facebook/fatal/community) and increase the visibility of our COC.

test plan:
Viewing it on my branch -
<img width="1008" alt="screen shot 2017-12-06 at 6 37 44 am" src="https://user-images.githubusercontent.com/1114467/33667059-a29e2828-da50-11e7-910c-6f9220b8137f.png">
<img width="1000" alt="screen shot 2017-12-06 at 6 37 51 am" src="https://user-images.githubusercontent.com/1114467/33667060-a2b8197c-da50-11e7-833a-79869965c0e8.png">

issue:
internal task t23481323