### PR TITLE
Cut CI support for c++11 and for gcc-4.8 and gcc-4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,42 +14,6 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-4.9']
-      env:
-        COMPILER=g++-4.9
-        CPP_STD=c++11
-
-    - os: linux
-      dist: trusty
-      sudo: false
-      compiler: gcc
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-4.9']
-      env:
-        COMPILER=g++-4.9
-        CPP_STD=c++14
-
-    - os: linux
-      dist: trusty
-      sudo: false
-      compiler: gcc
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-5']
-      env:
-        COMPILER=g++-5
-        CPP_STD=c++11
-
-    - os: linux
-      dist: trusty
-      sudo: false
-      compiler: gcc
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-5']
       env:
         COMPILER=g++-5
@@ -66,18 +30,6 @@ matrix:
       env:
         COMPILER=g++-5
         CPP_STD=c++1z
-
-    - os: linux
-      dist: trusty
-      sudo: false
-      compiler: gcc
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-6']
-      env:
-        COMPILER=g++-6
-        CPP_STD=c++11
 
     - os: linux
       dist: trusty
@@ -113,19 +65,6 @@ matrix:
           packages: ['clang-3.5', 'g++-6']
       env:
         COMPILER=clang++-3.5
-        CPP_STD=c++11
-        #USE_STDLIB=libc++
-
-    - os: linux
-      dist: trusty
-      sudo: false
-      compiler: clang
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.5']
-          packages: ['clang-3.5', 'g++-6']
-      env:
-        COMPILER=clang++-3.5
         CPP_STD=c++14
         #USE_STDLIB=libc++
 
@@ -140,19 +79,6 @@ matrix:
       env:
         COMPILER=clang++-3.5
         CPP_STD=c++1z
-        #USE_STDLIB=libc++
-
-    - os: linux
-      dist: trusty
-      sudo: false
-      compiler: clang
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.6']
-          packages: ['clang-3.6', 'g++-6']
-      env:
-        COMPILER=clang++-3.6
-        CPP_STD=c++11
         #USE_STDLIB=libc++
 
     - os: linux
@@ -191,19 +117,6 @@ matrix:
           packages: ['clang-3.7', 'g++-6']
       env:
         COMPILER=clang++-3.7
-        CPP_STD=c++11
-        #USE_STDLIB=libc++
-
-    - os: linux
-      dist: precise
-      sudo: false
-      compiler: clang
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
-          packages: ['clang-3.7', 'g++-6']
-      env:
-        COMPILER=clang++-3.7
         CPP_STD=c++14
         #USE_STDLIB=libc++
 
@@ -230,19 +143,6 @@ matrix:
           packages: ['clang-3.8', 'g++-6']
       env:
         COMPILER=clang++-3.8
-        CPP_STD=c++11
-        #USE_STDLIB=libc++
-
-    - os: linux
-      dist: trusty
-      sudo: false
-      compiler: clang
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.8']
-          packages: ['clang-3.8', 'g++-6']
-      env:
-        COMPILER=clang++-3.8
         CPP_STD=c++14
         #USE_STDLIB=libc++
 
@@ -257,19 +157,6 @@ matrix:
       env:
         COMPILER=clang++-3.8
         CPP_STD=c++1z
-        #USE_STDLIB=libc++
-
-    - os: linux
-      dist: trusty
-      sudo: false
-      compiler: clang
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.9']
-          packages: ['clang-3.9', 'g++-6']
-      env:
-        COMPILER=clang++-3.9
-        CPP_STD=c++11
         #USE_STDLIB=libc++
 
     - os: linux
@@ -297,20 +184,6 @@ matrix:
         COMPILER=clang++-3.9
         CPP_STD=c++1z
         #USE_STDLIB=libc++
-
-    # clang 4.0 is currently unsupported
-    #- os: linux
-    #  dist: trusty
-    #  sudo: false
-    #  compiler: clang
-    #  addons:
-    #    apt:
-    #      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
-    #      packages: ['clang-4.0', 'g++-6']
-    #  env:
-    #    COMPILER=clang++-4.0
-    #    CPP_STD=c++11
-    #    USE_STDLIB=libc++
 
     # clang 4.0 is currently unsupported
     #- os: linux
@@ -350,19 +223,6 @@ matrix:
           packages: ['clang-5.0', 'g++-6']
       env:
         COMPILER=clang++-5.0
-        CPP_STD=c++11
-        #USE_STDLIB=libc++
-
-    - os: linux
-      dist: trusty
-      sudo: false
-      compiler: clang
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
-          packages: ['clang-5.0', 'g++-6']
-      env:
-        COMPILER=clang++-5.0
         CPP_STD=c++14
         #USE_STDLIB=libc++
 
@@ -389,19 +249,6 @@ matrix:
     #      packages: ['clang-6.0', 'g++-6']
     #  env:
     #    COMPILER=clang++-6.0
-    #    CPP_STD=c++11
-    #    USE_STDLIB=libc++
-
-    #- os: linux
-    #  dist: trusty
-    #  sudo: false
-    #  compiler: clang
-    #  addons:
-    #    apt:
-    #      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
-    #      packages: ['clang-6.0', 'g++-6']
-    #  env:
-    #    COMPILER=clang++-6.0
     #    CPP_STD=c++14
     #    USE_STDLIB=libc++
 
@@ -417,14 +264,6 @@ matrix:
     #    COMPILER=clang++-6.0
     #    CPP_STD=c++1z
     #    USE_STDLIB=libc++
-
-# Activate when we are allowed to use MacOS X
-#    - os: osx
-#      compiler: clang
-#      env:
-#        COMPILER=clang++
-#        CPP_STD=c++11
-#        USE_STDLIB=libc++
 
 # Activate when we are allowed to use MacOS X
 #    - os: osx

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Fatal is a header only library, therefore no building is required.
 
 
 ## Requirements
-A compliant C++11 compiler. Currently tested under Clang {[3.5](https://packages.debian.org/sid/clang-3.5), [3.6](https://packages.debian.org/sid/clang-3.6), [3.7](https://packages.debian.org/sid/clang-3.7), [3.8](https://packages.debian.org/sid/clang-3.8), [3.9](https://packages.debian.org/sid/clang-3.9), [5.0](https://packages.debian.org/sid/clang-5.0)} and GCC {[4.9](https://packages.debian.org/sid/g++-4.9), [5](https://packages.debian.org/sid/g++-5), [6](https://packages.debian.org/sid/g++-6)}.
+A compliant C++14 compiler. Currently tested under Clang {[3.5](https://packages.debian.org/sid/clang-3.5), [3.6](https://packages.debian.org/sid/clang-3.6), [3.7](https://packages.debian.org/sid/clang-3.7), [3.8](https://packages.debian.org/sid/clang-3.8), [3.9](https://packages.debian.org/sid/clang-3.9), [5.0](https://packages.debian.org/sid/clang-5.0)} and GCC {[5](https://packages.debian.org/sid/g++-5), [6](https://packages.debian.org/sid/g++-6)}.
 
 There are no other external dependencies.
 
@@ -50,12 +50,12 @@ For Clang and GCC, it suffices to either:
 
 ## Building Benchmarks and Unit Tests
 ```sh
-$ clang++ -Wall -Werror -O2 -std=c++11 -I path/to/fatal \
+$ clang++ -Wall -Werror -O2 -std=c++14 -I path/to/fatal \
   -o path/to/output/binary path/to/test/or/benchmark.cpp \
 ```
 or
 ```sh
-$ g++ -Wall -Werror -O2 -std=c++11 -I path/to/fatal \
+$ g++ -Wall -Werror -O2 -std=c++14 -I path/to/fatal \
   -o path/to/output/binary path/to/test/or/benchmark.cpp \
 ```
 

--- a/compile.sh
+++ b/compile.sh
@@ -19,7 +19,7 @@ if [ "${USE_CC:0:5}" = "clang" ]; then
 fi
 
 if [ -z "$USE_STD" ]; then
-  export USE_STD="c++11"
+  export USE_STD="c++14"
 fi
 
 CC_STDLIB=""

--- a/compilers.conf
+++ b/compilers.conf
@@ -3,24 +3,11 @@ lowest_clang="clang++-3.5"
 alt_clang_list="clang++-3.6 clang++-3.7 clang++-3.8 clang++-3.9"
 
 highest_gcc="g++-7"
-lowest_gcc="g++-4.9"
-alt_gcc_list="g++-5 g++-6"
-
-flag_std_cpp11() {
-	case $1 in
-		g++-4.8)
-			echo "c++0x"
-			;;
-		*)
-			echo "c++11"
-			;;
-	esac
-}
+lowest_gcc="g++-5"
+alt_gcc_list="g++-6"
 
 flag_std_cpp14() {
 	case $1 in
-		g++-4.8)
-			;;
 		*)
 			echo "c++14"
 			;;
@@ -29,8 +16,6 @@ flag_std_cpp14() {
 
 flag_std_cpp17() {
 	case $1 in
-		g++-4.[8-9])
-			;;
 		*)
 			echo "c++1z"
 			;;

--- a/full_compile.sh
+++ b/full_compile.sh
@@ -7,7 +7,7 @@ set -e
 lclear
 
 for cc in $full_compilers_list; do
-  for std in `flag_std_cpp11 $cc` `flag_std_cpp14 $cc` `flag_std_cpp17 $cc`; do
+  for std in `flag_std_cpp14 $cc` `flag_std_cpp17 $cc`; do
     NO_CLEAR=true USE_CC="$cc" USE_STD="$std" ./compile.sh "$@"
   done
 done

--- a/full_test.sh
+++ b/full_test.sh
@@ -7,7 +7,7 @@ set -e
 lclear
 
 for cc in $full_compilers_list; do
-  for std in `flag_std_cpp11 $cc` `flag_std_cpp14 $cc` `flag_std_cpp17 $cc`; do
+  for std in `flag_std_cpp14 $cc` `flag_std_cpp17 $cc`; do
     NO_CLEAR=true USE_CC="$cc" USE_STD="$std" ./test.sh "$@"
   done
 done

--- a/lesson/1.1-values.cpp
+++ b/lesson/1.1-values.cpp
@@ -82,9 +82,8 @@ LESSON(
   constexpr int const int_constant_proper<Value>::value;
 ) {
   COMMENT(
-    "C++11 introduced the `constexpr` keyword which roughly allows us to tell "
-    "the compiler that a given variable holds the result of a constant "
-    "expression."
+    "The `constexpr` keyword roughly allows us to tell the compiler that a "
+    "given variable holds the result of a constant expression."
     "\n\n"
     "Once we have such guarantee, the compiler can evaluate the contents of "
     "such variable at compile time, effectivelly making it a compile time "

--- a/lesson/README.md
+++ b/lesson/README.md
@@ -51,18 +51,18 @@ Due to its REPL nature, Metashell provides a much more dynamic environment than 
 
 
 ## Requirements for lessons
-A compliant C++11 compiler. Currently tested under Clang {[3.4](https://packages.debian.org/sid/clang-3.4), [3.5](https://packages.debian.org/sid/clang-3.5), [3.6](https://packages.debian.org/sid/clang-3.6), [3.7](https://packages.debian.org/sid/clang-3.7), [3.8](https://packages.debian.org/sid/clang-3.8)} and GCC {[4.8.5+](https://packages.debian.org/sid/g++-4.8), [4.9](https://packages.debian.org/sid/g++-4.9), [5](https://packages.debian.org/sid/g++-5)}.
+A compliant C++14 compiler. Currently tested under Clang {[3.4](https://packages.debian.org/sid/clang-3.4), [3.5](https://packages.debian.org/sid/clang-3.5), [3.6](https://packages.debian.org/sid/clang-3.6), [3.7](https://packages.debian.org/sid/clang-3.7), [3.8](https://packages.debian.org/sid/clang-3.8)} and GCC {[5](https://packages.debian.org/sid/g++-5)}.
 
 There are no other external dependencies.
 
 
 ## Building lessons
 ```sh
-$ clang++ -std=c++11 -I path/to/fatal \
+$ clang++ -std=c++14 -I path/to/fatal \
   -o path/to/output/binary lesson/lesson_filename.cpp
 ```
 or
 ```sh
-$ g++ -std=c++11 -I path/to/fatal \
+$ g++ -std=c++14 -I path/to/fatal \
   -o path/to/output/binary lesson/lesson_filename.cpp
 ```

--- a/local_contbuild.sh
+++ b/local_contbuild.sh
@@ -5,7 +5,7 @@
 set -e
 
 for cc in $full_compilers_list; do
-  for std in `flag_std_cpp11 $cc` `flag_std_cpp14 $cc` `flag_std_cpp17 $cc`; do
+  for std in `flag_std_cpp14 $cc` `flag_std_cpp17 $cc`; do
     echo "## contbuild $cc $std"
     EXCLUDE_BENCHMARKS=true ./contbuild.sh "$cc" "$std"
     echo

--- a/profile.sh
+++ b/profile.sh
@@ -10,7 +10,7 @@ if [ -z "$1" ]; then
 fi
 
 if [ -z "$USE_STD" ]; then
-  export USE_STD="c++11"
+  export USE_STD="c++14"
 fi
 
 export USE_CC="templight"

--- a/smoke_build.sh
+++ b/smoke_build.sh
@@ -13,14 +13,12 @@ if [ -z "$BE_LENIENT" ]; then
 fi
 
 for cc in $full_compilers_list; do
-  for std in `flag_std_cpp11 $cc` `flag_std_cpp14 $cc` `flag_std_cpp17 $cc`; do
+  for std in `flag_std_cpp14 $cc` `flag_std_cpp17 $cc`; do
     echo "## full build $cc $std"
     USE_CC="$cc" USE_STD="$std" USE_CCACHE=true NO_CLEAR=true ./build.sh
-    if [ "$std" != "`flag_std_cpp11 $cc`" ]; then
-      for f in `find demo -name '*.cpp'`; do
-        USE_CC="$cc" USE_STD="$std" USE_CCACHE=true NO_CLEAR=true ./compile.sh "$f"
-      done
-    fi
+    for f in `find demo -name '*.cpp'`; do
+      USE_CC="$cc" USE_STD="$std" USE_CCACHE=true NO_CLEAR=true ./compile.sh "$f"
+    done
     echo
     echo
   done

--- a/validate.sh
+++ b/validate.sh
@@ -20,10 +20,6 @@ while [ "$1" ]; do
   shift
 done
 
-if [ "$USE_STD" = "c++11" ] || [ "$USE_STD" = "c++0x" ]; then
-  skip_demo=true
-fi
-
 run_validation() {
   cc="$1"
 
@@ -41,7 +37,7 @@ run_validation() {
     CC_OPT="-O0" USE_CC="$cc" NO_CLEAR=true ./test.sh
   fi
 
-  if [ "$skip_demo" != "true" ] && [ "$cc" != "g++-4.8" ]; then
+  if [ "$skip_demo" != "true" ]; then
     for demo in ytse_jam; do
       echo -n | CC_OPT="-O0" USE_CC="$cc" NO_CLEAR=true ./demo.sh $demo
     done


### PR DESCRIPTION
Summary: [Fatal] Cut CI support for `c++11` and for `gcc-4.8` and `gcc-4.9`.

Differential Revision: D16802168

