### PR TITLE
Switch Travis config to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: cpp
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: gcc
       addons:
@@ -20,7 +20,7 @@ matrix:
         CPP_STD=c++14
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: gcc
       addons:
@@ -32,7 +32,7 @@ matrix:
         CPP_STD=c++1z
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: gcc
       addons:
@@ -44,7 +44,7 @@ matrix:
         CPP_STD=c++14
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: gcc
       addons:
@@ -56,12 +56,12 @@ matrix:
         CPP_STD=c++1z
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.5']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.5']
           packages: ['clang-3.5', 'g++-6']
       env:
         COMPILER=clang++-3.5
@@ -69,12 +69,12 @@ matrix:
         #USE_STDLIB=libc++
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.5']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.5']
           packages: ['clang-3.5', 'g++-6']
       env:
         COMPILER=clang++-3.5
@@ -82,12 +82,12 @@ matrix:
         #USE_STDLIB=libc++
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.6']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.6']
           packages: ['clang-3.6', 'g++-6']
       env:
         COMPILER=clang++-3.6
@@ -95,12 +95,12 @@ matrix:
         #USE_STDLIB=libc++
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.6']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.6']
           packages: ['clang-3.6', 'g++-6']
       env:
         COMPILER=clang++-3.6
@@ -134,12 +134,12 @@ matrix:
         #USE_STDLIB=libc++
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.8']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.8']
           packages: ['clang-3.8', 'g++-6']
       env:
         COMPILER=clang++-3.8
@@ -147,12 +147,12 @@ matrix:
         #USE_STDLIB=libc++
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.8']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.8']
           packages: ['clang-3.8', 'g++-6']
       env:
         COMPILER=clang++-3.8
@@ -160,12 +160,12 @@ matrix:
         #USE_STDLIB=libc++
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.9']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.9']
           packages: ['clang-3.9', 'g++-6']
       env:
         COMPILER=clang++-3.9
@@ -173,12 +173,12 @@ matrix:
         #USE_STDLIB=libc++
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.9']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-3.9']
           packages: ['clang-3.9', 'g++-6']
       env:
         COMPILER=clang++-3.9
@@ -187,12 +187,12 @@ matrix:
 
     # clang 4.0 is currently unsupported
     #- os: linux
-    #  dist: trusty
+    #  dist: xenial
     #  sudo: false
     #  compiler: clang
     #  addons:
     #    apt:
-    #      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
+    #      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-4.0']
     #      packages: ['clang-4.0', 'g++-6']
     #  env:
     #    COMPILER=clang++-4.0
@@ -201,12 +201,12 @@ matrix:
 
     # clang 4.0 is currently unsupported
     #- os: linux
-    #  dist: trusty
+    #  dist: xenial
     #  sudo: false
     #  compiler: clang
     #  addons:
     #    apt:
-    #      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
+    #      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-4.0']
     #      packages: ['clang-4.0', 'g++-6']
     #  env:
     #    COMPILER=clang++-4.0
@@ -214,12 +214,12 @@ matrix:
     #    USE_STDLIB=libc++
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-5.0']
           packages: ['clang-5.0', 'g++-6']
       env:
         COMPILER=clang++-5.0
@@ -227,12 +227,12 @@ matrix:
         #USE_STDLIB=libc++
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-5.0']
           packages: ['clang-5.0', 'g++-6']
       env:
         COMPILER=clang++-5.0
@@ -240,12 +240,12 @@ matrix:
         #USE_STDLIB=libc++
 
     #- os: linux
-    #  dist: trusty
+    #  dist: xenial
     #  sudo: false
     #  compiler: clang
     #  addons:
     #    apt:
-    #      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
+    #      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-6.0']
     #      packages: ['clang-6.0', 'g++-6']
     #  env:
     #    COMPILER=clang++-6.0
@@ -253,12 +253,12 @@ matrix:
     #    USE_STDLIB=libc++
 
     #- os: linux
-    #  dist: trusty
+    #  dist: xenial
     #  sudo: false
     #  compiler: clang
     #  addons:
     #    apt:
-    #      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
+    #      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-xenial-6.0']
     #      packages: ['clang-6.0', 'g++-6']
     #  env:
     #    COMPILER=clang++-6.0


### PR DESCRIPTION
Summary: [Fatal] Switch Travis config to Xenial (Ubuntu 16.04 LTS) from Trusty (Ubuntu 14.04 LTS).

Differential Revision: D17391658

