### PR TITLE
fix destructor call in circular_queue pop_front count

### DIFF
--- a/fatal/container/circular_queue.h
+++ b/fatal/container/circular_queue.h
@@ -261,7 +261,7 @@ public:
     FATAL_ASSUME_LE(chunk, count);
     FATAL_ASSUME_EQ(offset_ == 0, count == chunk);
     for (auto const end = count - chunk; offset_ < end; ++offset_) {
-      queue_[offset_].~value_type();
+      queue_[offset_].value.~value_type();
     }
 
     size_ -= count;


### PR DESCRIPTION
see in circular_queue pop_front with count there is one small mistake queue offset destructor is called directly but it should call value destructor because queue element is union item_t and destructor must be called on value clang is giving compile error when using std string i changed it to queue offset dot value destructor and tested with std string in wrapping case now it compiles and works fine